### PR TITLE
Remove babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["env", "stage-0"]
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rwgps/units",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Unit conversion and formatting",
   "main": "src/index.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rwgps/units",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Unit conversion and formatting",
   "main": "src/index.js",
   "dependencies": {},


### PR DESCRIPTION
remove the babelrc, since this breaks the ability of this module to be used in other ES6 projects without precompiling:

<img width="868" alt="Screen Shot 2019-03-12 at 11 33 55 AM" src="https://user-images.githubusercontent.com/347189/54222327-ccace700-44ba-11e9-897b-191ab31a17a0.png">
